### PR TITLE
Make instruction more idiot proof

### DIFF
--- a/assignments/P-commoncrawl.md
+++ b/assignments/P-commoncrawl.md
@@ -99,7 +99,7 @@ Then try out the standard example to compute Pi through a random process.
 just ignore the warning about `yarn-cluster` being deprecated.)
 
 ```
-cd spark
+cd /hathi-client/spark
 MASTER=yarn-cluster bin/run-example SparkPi
 ```
 


### PR DESCRIPTION
The instructions say 

```
cd spark
MASTER=yarn-cluster bin/run-example SparkPi
```

assuming that you are already in the `/hathi-client` folder, which is not the case if you followed the instructions before without modifications. Seems like this used to be true, because there is the following commented out snipped left in the file:

```
cd hathi-client
bin/get.sh spark
```

But as mentioned, it has been commented out. Anyway this is easy to fix, if you just use the full path.